### PR TITLE
Fix build on Linux

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,13 +11,15 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-14
+          - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-      - uses: Homebrew/actions/setup-homebrew@master
+      - uses: swatinem/rust-cache@v2
+      - uses: homebrew/actions/setup-homebrew@master
       - run: tools/setup.sh
+      - run: $MLIR_SYS_190_PREFIX/bin/llvm-config --link-static --libnames
+      - run: ls -1 $($MLIR_SYS_190_PREFIX/bin/llvm-config --link-static --libdir) | sort
       - run: cargo test
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,8 +18,6 @@ jobs:
       - uses: swatinem/rust-cache@v2
       - uses: homebrew/actions/setup-homebrew@master
       - run: tools/setup.sh
-      - run: $MLIR_SYS_190_PREFIX/bin/llvm-config --link-static --libnames
-      - run: ls -1 $($MLIR_SYS_190_PREFIX/bin/llvm-config --link-static --libdir) | sort
       - run: cargo test
   lint:
     runs-on: ubuntu-latest

--- a/build.rs
+++ b/build.rs
@@ -33,7 +33,7 @@ fn run() -> Result<(), Box<dyn Error>> {
     for entry in read_dir(llvm_config("--libdir")?)? {
         if let Some(name) = entry?.path().file_name().and_then(OsStr::to_str) {
             if name.starts_with("libMLIRCAPI") {
-                if let Some(name) = parse_archive_name(&name) {
+                if let Some(name) = parse_archive_name(name) {
                     println!("cargo:rustc-link-lib=static={name}");
                 }
             }

--- a/build.rs
+++ b/build.rs
@@ -62,13 +62,10 @@ fn run() -> Result<(), Box<dyn Error>> {
             );
             println!(
                 "cargo:rustc-link-lib={}",
-                path.file_name()
+                path.file_stem()
                     .unwrap()
                     .to_str()
                     .unwrap()
-                    .split_once('.')
-                    .unwrap()
-                    .0
                     .trim_start_matches("lib")
             );
         } else {

--- a/build.rs
+++ b/build.rs
@@ -43,7 +43,7 @@ fn run() -> Result<(), Box<dyn Error>> {
         .into_iter()
         .flatten()
         .collect::<Vec<_>>();
-    libraries.sort_by(|one, other| one.contains("LLVM").cmp(&other.contains("LLVM")));
+    libraries.sort_by_key(|name| name.len());
 
     for name in libraries {
         if name.starts_with("libMLIR") && name.ends_with(".a") && !name.contains("Main") {

--- a/build.rs
+++ b/build.rs
@@ -20,10 +20,9 @@ fn main() {
 fn run() -> Result<(), Box<dyn Error>> {
     let version = llvm_config("--version")?;
 
-    if !version.starts_with(&format!("{}.", LLVM_MAJOR_VERSION)) {
+    if !version.starts_with(&format!("{LLVM_MAJOR_VERSION}.",)) {
         return Err(format!(
-            "failed to find correct version ({}.x.x) of llvm-config (found {})",
-            LLVM_MAJOR_VERSION, version
+            "failed to find correct version ({LLVM_MAJOR_VERSION}.x.x) of llvm-config (found {version})"
         )
         .into());
     }
@@ -45,7 +44,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 
     for name in llvm_config("--libnames")?.trim().split(' ') {
         if let Some(name) = parse_archive_name(name) {
-            println!("cargo:rustc-link-lib={}", name);
+            println!("cargo:rustc-link-lib={name}");
         }
     }
 
@@ -69,12 +68,12 @@ fn run() -> Result<(), Box<dyn Error>> {
                     .trim_start_matches("lib")
             );
         } else {
-            println!("cargo:rustc-link-lib={}", flag);
+            println!("cargo:rustc-link-lib={flag}");
         }
     }
 
     if let Some(name) = get_system_libcpp() {
-        println!("cargo:rustc-link-lib={}", name);
+        println!("cargo:rustc-link-lib={name}");
     }
 
     bindgen::builder()
@@ -99,13 +98,12 @@ fn get_system_libcpp() -> Option<&'static str> {
 }
 
 fn llvm_config(argument: &str) -> Result<String, Box<dyn Error>> {
-    let prefix = env::var(format!("MLIR_SYS_{}0_PREFIX", LLVM_MAJOR_VERSION))
+    let prefix = env::var(format!("MLIR_SYS_{LLVM_MAJOR_VERSION}0_PREFIX"))
         .map(|path| Path::new(&path).join("bin"))
         .unwrap_or_default();
     let call = format!(
-        "{} --link-static {}",
+        "{} --link-static {argument}",
         prefix.join("llvm-config").display(),
-        argument
     );
 
     Ok(str::from_utf8(

--- a/build.rs
+++ b/build.rs
@@ -30,6 +30,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 
     println!("cargo:rerun-if-changed=wrapper.h");
     println!("cargo:rustc-link-search={}", llvm_config("--libdir")?);
+    println!("cargo:rustc-link-lib=MLIR");
 
     let mut libraries = read_dir(llvm_config("--libdir")?)?
         .map(|entry| {
@@ -46,7 +47,7 @@ fn run() -> Result<(), Box<dyn Error>> {
     libraries.sort_by_key(|name| name.len());
 
     for name in libraries {
-        if name.starts_with("libMLIR") && name.ends_with(".a") && !name.contains("Main") {
+        if name.starts_with("libMLIRCAPI") && name.ends_with(".a") {
             if let Some(name) = trim_library_name(&name) {
                 println!("cargo:rustc-link-lib=static={name}");
             }

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,8 @@
 use std::{
     env,
     error::Error,
-    fs, io,
+    fs::read_dir,
+    io,
     path::Path,
     process::{exit, Command},
     str,
@@ -30,7 +31,7 @@ fn run() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=wrapper.h");
     println!("cargo:rustc-link-search={}", llvm_config("--libdir")?);
 
-    for name in fs::read_dir(llvm_config("--libdir")?)?
+    for name in read_dir(llvm_config("--libdir")?)?
         .map(|entry| {
             Ok(if let Some(name) = entry?.path().file_name() {
                 name.to_str().map(String::from)
@@ -42,13 +43,9 @@ fn run() -> Result<(), Box<dyn Error>> {
         .into_iter()
         .flatten()
     {
-        if name.starts_with("libMLIR")
-            && name.ends_with(".a")
-            && !name.contains("Main")
-            && name != "libMLIRSupportIndentedOstream.a"
-        {
+        if name.starts_with("libMLIR") && name.ends_with(".a") && !name.contains("Main") {
             if let Some(name) = trim_library_name(&name) {
-                println!("cargo:rustc-link-lib=static={}", name);
+                println!("cargo:rustc-link-lib=static={name}");
             }
         }
     }

--- a/build.rs
+++ b/build.rs
@@ -30,9 +30,8 @@ fn run() -> Result<(), Box<dyn Error>> {
 
     println!("cargo:rerun-if-changed=wrapper.h");
     println!("cargo:rustc-link-search={}", llvm_config("--libdir")?);
-    println!("cargo:rustc-link-lib=MLIR");
 
-    let mut libraries = read_dir(llvm_config("--libdir")?)?
+    let libraries = read_dir(llvm_config("--libdir")?)?
         .map(|entry| {
             Ok(if let Some(name) = entry?.path().file_name() {
                 name.to_str().map(String::from)
@@ -44,7 +43,6 @@ fn run() -> Result<(), Box<dyn Error>> {
         .into_iter()
         .flatten()
         .collect::<Vec<_>>();
-    libraries.sort_by_key(|name| name.len());
 
     for name in libraries {
         if name.starts_with("libMLIRCAPI") && name.ends_with(".a") {
@@ -53,6 +51,8 @@ fn run() -> Result<(), Box<dyn Error>> {
             }
         }
     }
+
+    println!("cargo:rustc-link-lib=MLIR");
 
     for name in llvm_config("--libnames")?.trim().split(' ') {
         if let Some(name) = trim_library_name(name) {

--- a/build.rs
+++ b/build.rs
@@ -43,6 +43,7 @@ fn run() -> Result<(), Box<dyn Error>> {
         .flatten()
     {
         if name.starts_with("libMLIR")
+            && name.ends_with(".a")
             && !name.contains("Main")
             && name != "libMLIRSupportIndentedOstream.a"
         {

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -7,4 +7,7 @@ llvm_version=19
 brew update
 brew install llvm@$llvm_version
 
-echo MLIR_SYS_${llvm_version}0_PREFIX=$(brew --prefix llvm@$llvm_version) >>$GITHUB_ENV
+llvm_prefix=$(brew --prefix llvm@$llvm_version)
+
+echo MLIR_SYS_${llvm_version}0_PREFIX=$llvm_prefix >>$GITHUB_ENV
+echo LD_LIBRARY_PATH=$llvm_prefix/lib:$LD_LIBRARY_PATH >>$GITHUB_ENV


### PR DESCRIPTION
I'm not sure how to keep static linking of MLIR `.a` libraries and their proper link order without something like `llvm-config`. We fall back to normal `-lMLIR` for now.

I believe that users can still use fully static linking of MLIR when they have its custom build.