### PR TITLE
Fix build again for extra APIs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,20 @@ on:
       - main
   pull_request:
 jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: swatinem/rust-cache@v2
+      - uses: homebrew/actions/setup-homebrew@master
+      - run: tools/setup.sh
+      - run: cargo build
   test:
     strategy:
       fail-fast: false

--- a/build.rs
+++ b/build.rs
@@ -32,7 +32,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 
     for entry in read_dir(llvm_config("--libdir")?)? {
         if let Some(name) = entry?.path().file_name().and_then(OsStr::to_str) {
-            if name.starts_with("libMLIRCAPI") {
+            if name.starts_with("libMLIR") {
                 if let Some(name) = parse_archive_name(name) {
                     println!("cargo:rustc-link-lib=static={name}");
                 }


### PR DESCRIPTION
The `libMLIR*` libraries still seem to need to be linked but not only `libMLIR` even when it's a shared object.
