### PR TITLE
Upgrade to LLVM 21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mlir-sys"
-version = "0.5.0"
+version = "210.0.0"
 authors = ["McCoy R. Becker", "Yota Toyama", "Edgar Luque"]
 keywords = ["mlir", "llvm"]
 categories = ["external-ffi-bindings"]

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Rust bindings to [the MLIR C API](https://mlir.llvm.org/docs/CAPI/).
 
 ## Versioning
 
-The versioning scheme follows the LLVM version used, similar to `llvm-sys`. The crate version is the LLVM version multiplied by 10 with a patch version:
+Starting with LLVM 21, this crate follows a versioning scheme similar to `llvm-sys`. The crate version is the LLVM version multiplied by 10 with a patch version:
 
 - `mlir-sys` 210.0.x is compatible with LLVM/MLIR 21.0.x
-- `mlir-sys` 200.0.x is compatible with LLVM/MLIR 20.0.x
+- Previous versions (0.x.x) used a different versioning scheme
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,20 @@
 
 Rust bindings to [the MLIR C API](https://mlir.llvm.org/docs/CAPI/).
 
+## Versioning
+
+The versioning scheme follows the LLVM version used, similar to `llvm-sys`. The crate version is the LLVM version multiplied by 10 with a patch version:
+
+- `mlir-sys` 210.0.x is compatible with LLVM/MLIR 21.0.x
+- `mlir-sys` 200.0.x is compatible with LLVM/MLIR 20.0.x
+
 ## Install
 
 ```sh
 cargo add mlir-sys
 ```
 
-This crate searches an `llvm-config` command on build and uses it to determine build configurations related to LLVM and MLIR. You can also use a `MLIR_SYS_190_PREFIX` environment variable to specify a custom directory of LLVM installation.
+This crate searches an `llvm-config` command on build and uses it to determine build configurations related to LLVM and MLIR. You can also use a `MLIR_SYS_210_PREFIX` environment variable to specify a custom directory of LLVM installation.
 
 ## License
 

--- a/build.rs
+++ b/build.rs
@@ -31,12 +31,11 @@ fn run() -> Result<(), Box<dyn Error>> {
     println!("cargo:rustc-link-search={}", llvm_config("--libdir")?);
 
     for entry in read_dir(llvm_config("--libdir")?)? {
-        if let Some(name) = entry?.path().file_name().and_then(OsStr::to_str) {
-            if name.starts_with("libMLIR") {
-                if let Some(name) = parse_archive_name(name) {
-                    println!("cargo:rustc-link-lib=static={name}");
-                }
-            }
+        if let Some(name) = entry?.path().file_name().and_then(OsStr::to_str)
+            && name.starts_with("libMLIR")
+            && let Some(name) = parse_archive_name(name)
+        {
+            println!("cargo:rustc-link-lib=static={name}");
         }
     }
 

--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ use std::{
     str,
 };
 
-const LLVM_MAJOR_VERSION: usize = 20;
+const LLVM_MAJOR_VERSION: usize = 21;
 
 fn main() {
     if let Err(error) = run() {

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -19,11 +19,32 @@ if [ "$(uname)" = "Darwin" ]; then
     fi
 elif [ "$(uname)" = "Linux" ]; then
     # Linux (Ubuntu)
-    # First try to install LLVM from apt
-    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-    sudo apt-add-repository "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${llvm_version} main" || true
+    # For LLVM 21, we need to install from the development branch
+    wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+    
+    # Determine Ubuntu codename
+    codename=$(lsb_release -cs)
+    
+    # Add the appropriate repository
+    echo "deb http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${llvm_version} main" | sudo tee /etc/apt/sources.list.d/llvm-${llvm_version}.list
+    echo "deb-src http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${llvm_version} main" | sudo tee -a /etc/apt/sources.list.d/llvm-${llvm_version}.list
+    
     sudo apt-get update
-    sudo apt-get install -y llvm-${llvm_version} llvm-${llvm_version}-dev
+    
+    # Install LLVM packages with MLIR support
+    # Note: MLIR packages might have different naming conventions
+    sudo apt-get install -y \
+        llvm-${llvm_version} \
+        llvm-${llvm_version}-dev \
+        llvm-${llvm_version}-tools \
+        clang-${llvm_version} \
+        libclang-${llvm_version}-dev \
+        liblld-${llvm_version}-dev \
+        || {
+        echo "Error: Failed to install LLVM ${llvm_version}"
+        echo "Please check if LLVM ${llvm_version} is available for your Ubuntu version at https://apt.llvm.org/"
+        exit 1
+    }
     
     llvm_prefix=/usr/lib/llvm-${llvm_version}
 else

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-llvm_version=20
+llvm_version=21
 
 brew update
 brew install llvm@$llvm_version

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -32,7 +32,6 @@ elif [ "$(uname)" = "Linux" ]; then
     sudo apt-get update
     
     # Install LLVM packages with MLIR support
-    # Note: MLIR packages might have different naming conventions
     sudo apt-get install -y \
         llvm-${llvm_version} \
         llvm-${llvm_version}-dev \
@@ -40,6 +39,8 @@ elif [ "$(uname)" = "Linux" ]; then
         clang-${llvm_version} \
         libclang-${llvm_version}-dev \
         liblld-${llvm_version}-dev \
+        libmlir-${llvm_version}-dev \
+        mlir-${llvm_version}-tools \
         || {
         echo "Error: Failed to install LLVM ${llvm_version}"
         echo "Please check if LLVM ${llvm_version} is available for your Ubuntu version at https://apt.llvm.org/"

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -5,9 +5,15 @@ set -e
 llvm_version=21
 
 brew update
-brew install llvm@$llvm_version
 
-llvm_prefix=$(brew --prefix llvm@$llvm_version)
+# For LLVM 21+, use the main llvm formula as versioned formulas aren't available yet
+if [ $llvm_version -ge 21 ]; then
+    brew install llvm
+    llvm_prefix=$(brew --prefix llvm)
+else
+    brew install llvm@$llvm_version
+    llvm_prefix=$(brew --prefix llvm@$llvm_version)
+fi
 
 echo MLIR_SYS_${llvm_version}0_PREFIX=$llvm_prefix >>$GITHUB_ENV
 echo LD_LIBRARY_PATH=$llvm_prefix/lib:$LD_LIBRARY_PATH >>$GITHUB_ENV

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -31,19 +31,16 @@ elif [ "$(uname)" = "Linux" ]; then
     
     sudo apt-get update
     
-    # Install LLVM packages with MLIR support
+    # Install minimal packages needed for MLIR C API bindings
+    # We need: MLIR dev files, LLVM libraries that MLIR depends on, and clang for bindgen
     sudo apt-get install -y \
-        llvm-${llvm_version} \
-        llvm-${llvm_version}-dev \
-        llvm-${llvm_version}-tools \
-        clang-${llvm_version} \
-        libclang-${llvm_version}-dev \
-        liblld-${llvm_version}-dev \
         libmlir-${llvm_version}-dev \
         mlir-${llvm_version}-tools \
+        llvm-${llvm_version}-dev \
+        clang-${llvm_version} \
         libpolly-${llvm_version}-dev \
         || {
-        echo "Error: Failed to install LLVM ${llvm_version}"
+        echo "Error: Failed to install LLVM ${llvm_version} packages"
         echo "Please check if LLVM ${llvm_version} is available for your Ubuntu version at https://apt.llvm.org/"
         exit 1
     }

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -4,15 +4,31 @@ set -e
 
 llvm_version=21
 
-brew update
-
-# For LLVM 21+, use the main llvm formula as versioned formulas aren't available yet
-if [ $llvm_version -ge 21 ]; then
-    brew install llvm
-    llvm_prefix=$(brew --prefix llvm)
+# Detect the operating system
+if [ "$(uname)" = "Darwin" ]; then
+    # macOS
+    brew update
+    
+    # For LLVM 21+, use the main llvm formula as versioned formulas aren't available yet
+    if [ $llvm_version -ge 21 ]; then
+        brew install llvm
+        llvm_prefix=$(brew --prefix llvm)
+    else
+        brew install llvm@$llvm_version
+        llvm_prefix=$(brew --prefix llvm@$llvm_version)
+    fi
+elif [ "$(uname)" = "Linux" ]; then
+    # Linux (Ubuntu)
+    # First try to install LLVM from apt
+    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+    sudo apt-add-repository "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${llvm_version} main" || true
+    sudo apt-get update
+    sudo apt-get install -y llvm-${llvm_version} llvm-${llvm_version}-dev
+    
+    llvm_prefix=/usr/lib/llvm-${llvm_version}
 else
-    brew install llvm@$llvm_version
-    llvm_prefix=$(brew --prefix llvm@$llvm_version)
+    echo "Unsupported operating system: $(uname)"
+    exit 1
 fi
 
 echo MLIR_SYS_${llvm_version}0_PREFIX=$llvm_prefix >>$GITHUB_ENV

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -41,6 +41,7 @@ elif [ "$(uname)" = "Linux" ]; then
         liblld-${llvm_version}-dev \
         libmlir-${llvm_version}-dev \
         mlir-${llvm_version}-tools \
+        libpolly-${llvm_version}-dev \
         || {
         echo "Error: Failed to install LLVM ${llvm_version}"
         echo "Please check if LLVM ${llvm_version} is available for your Ubuntu version at https://apt.llvm.org/"


### PR DESCRIPTION
This may look like a troll PR, but `cargo test` works for me with LLVM 21.1.1 on Debian stable.

Well, I have only tested in a fork that uses static linking instead of `-lMLIR` and I don't have a `libMLIR.so` on hand, so please test this yourself. But it should work. (The hack to do static linking of MLIR libs [[1][1],[2][2]] is unrelated and almost certainly too ugly to be merged.)

Related: mlir-rs/tblgen-rs#28

[1]: https://github.com/gt-tinker/qwerty/blob/2abca7773b5e8dc681ff6be05b3b9b73d7d59c1d/CMakeLists.txt#L122-L157
[2]: https://github.com/gt-tinker/qwerty-mlir-sys/blob/9174f41e78d82517d5394ce4d61a12ecd2440ac6/build.rs#L169